### PR TITLE
color and decorate links in the page-feature class

### DIFF
--- a/_sass/temple/_page.scss
+++ b/_sass/temple/_page.scss
@@ -67,8 +67,11 @@ main {
   background-color: $tu-cherry;
   background-size: cover;
   background-position: center right;
-  h1, h2, p {
+  h1, h2, p, a {
     color: white;
+  }
+  a {
+    text-decoration: underline;
   }
 }
 


### PR DESCRIPTION
This PR colors the `a` tag in the `.page-feature` class white and underlines the link. Previously the link color was `$tu-cherry` which was hard to read against a red background.

Example of linked text in the `.page-feature`:

![screenshot 2017-08-08 12 10 10](https://user-images.githubusercontent.com/1696777/29082107-8d0b2c80-7c32-11e7-95a8-78684cb84466.png)
