### PR TITLE
set padding on sidebar table rows

### DIFF
--- a/_sass/temple/_page.scss
+++ b/_sass/temple/_page.scss
@@ -89,6 +89,9 @@ main {
     border: 0;
     border-bottom: 1px solid #ccc;
   }
+  td {
+    padding: 0px;
+  }
 }
 
 // Page content


### PR DESCRIPTION
reducing the padding makes sidebar table items more compact and readable, like this:

![screenshot 2017-09-29 17 22 14](https://user-images.githubusercontent.com/1696777/31036556-c12568ce-a53a-11e7-9fa3-edff14f92605.png)
